### PR TITLE
Change path to correct download URI

### DIFF
--- a/programs.cfg
+++ b/programs.cfg
@@ -1,8 +1,8 @@
 {
    ["redfs"] = {
       files = {
-         ["redfs/redfs.lua"] = "/lib",
-         ["redfs/mount.redfs.lua"] = "/bin",
+         ["master/redfs/redfs.lua"] = "/lib",
+         ["master/redfs/mount.redfs.lua"] = "/bin",
       },
       name="Redstone FS",
       description="Provides a virtual filesystem that can control Redstone cards/blocks.",


### PR DESCRIPTION
Without "master" in the file path I get a "HTTP request failed" (404) error on installation.
He tries to download: https://raw.githubusercontent.com/SolraBizna/SolrOC/redfs/mount.redfs.lua
But he should download: https://raw.githubusercontent.com/SolraBizna/SolrOC/master/redfs/mount.redfs.lua